### PR TITLE
fixing bip39 mnemonic validator method

### DIFF
--- a/xchainpy/xchainpy_crypto/xchainpy_crypto/crypto.py
+++ b/xchainpy/xchainpy_crypto/xchainpy_crypto/crypto.py
@@ -32,7 +32,8 @@ def validate_phrase(phrase: str):
     :type phrase: str
     :returns: is the phrase valid or not (true or false)
     """
-    is_valid = Bip39MnemonicValidator(phrase).Validate()
+    #is_valid = Bip39MnemonicValidator(phrase).Validate()
+    is_valid = Bip39MnemonicValidator(phrase).IsValid()
     return is_valid
 
 def generate_mnemonic():


### PR DESCRIPTION
method: 
is_valid = Bip39MnemonicValidator(phrase).Validate()
returns None for 
bip-utils       1.10.0
changed to is_valid = Bip39MnemonicValidator(phrase).IsValid()