### PR TITLE
Fix bug in thorchain when sending a very first tx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+venv/
+.idea
 .vscode
 *.pyc
 dist/

--- a/xchainpy/xchainpy_thorchain/xchainpy_thorchain/cosmos/sdk_client.py
+++ b/xchainpy/xchainpy_thorchain/xchainpy_thorchain/cosmos/sdk_client.py
@@ -112,7 +112,8 @@ class CosmosSDKClient:
         if not self._account_num:
             account = await self.account_address_get(address=from_address)
             self._account_num = account['result']['value']['account_number']
-            self._sequence = account['result']['value']['sequence']
+            # there is no "sequence" for a fresh wallet, so we use "get" with default
+            self._sequence = account['result']['value'].get('sequence', '0')
 
         self._gas = "10000000"
         self._fee = "10000000"


### PR DESCRIPTION
I discovered that when you do a very first tx from a fresh wallet, there is no `sequence` field, so `KeyError` is raised. This commit fixes that issue by returning a default value when it is missing in the response.